### PR TITLE
chore: bump to 1.0.5

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "koa2-ssl",
   "description": "Enforce SSL for koa apps",
-  "version": "1.0.4",
+  "version": "1.0.5",
   "author": "Antoine Lépée <alepee@gmail.com>",
   "bugs": {
     "url": "https://github.com/alepee/koa2-ssl/issues"


### PR DESCRIPTION
### Changelog:
[bump handlebars from 4.0.12 to 4.1.2](https://github.com/alepee/koa2-ssl/pull/1)
[bump js-yaml from 3.12.0 to 3.13.1](https://github.com/alepee/koa2-ssl/pull/2)
[bump lodash from 4.17.5 to 4.17.14](https://github.com/alepee/koa2-ssl/pull/3)